### PR TITLE
Revision

### DIFF
--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -103,6 +103,11 @@ and exploration of epidemiological data.
 	
 ## Infectious disease modelling
 
+This section includes packages for specifically dedicated to IDE modelling. Note
+that R offers a wealth of options for general-purpose time series modelling,
+many of which are listed in the `r view("TimeSeries")` and `r view("Survival")`
+task views.
+
 ### Epidemics surveillance
 
 -   `r pkg("argo")`: Augmented Regression with General Online data (ARGO) for
@@ -114,11 +119,10 @@ and exploration of epidemiological data.
 -   `r pkg("Epi")`: Functions for demographic and epidemiological analysis in
     the Lexis diagram, i.e. register and cohort follow-up data, in particular
     representation, manipulation and simulation of multistate data - the Lexis
-    suite of functions, which includes interfaces to `r pkg("mstate")`,
-    `r pkg("etm")` and `r pkg("cmprsk")` packages. Also contains functions for
-    Age-Period-Cohort and Lee-Carter modeling and a function for interval
-    censored data and some useful functions for tabulation and plotting, as well
-    as a number of epidemiological data sets.
+    suite of functions, which includes interfaces to `r pkg("mstate")`, `r
+    pkg("etm")` and `r pkg("cmprsk")` packages. Also contains functions for
+    Age-Period-Cohort and Lee-Carter modelling, interval censored data,
+    tabulation, plotting, as well as a number of epidemiological data sets.
 -   `r pkg("episensr")`: Basic sensitivity analysis of the observed relative
     risks adjusting for unmeasured confounding and misclassification of the
     exposure/outcome, or both. It follows the bias analysis methods and examples
@@ -137,21 +141,20 @@ and exploration of epidemiological data.
     Lozano ([2012](https://doi.org/10.1111/j.1750-2659.2012.00422.x),
     [2015](https://doi.org/10.1111/irv.12330)), allows the weekly assessment of
     the epidemic and intensity status to help in routine respiratory infections
-    surveillance in health systems. Allows the comparison of different epidemic
+    surveillance in health systems. Enables the comparison of different epidemic
     indicators, timing and shape with past epidemics and across different
-    regions or countries with different surveillance systems. Also, it gives a
+    regions or countries with different surveillance systems. It also gives a
     measure of the performance of the method in terms of sensitivity and
     specificity of the alert week. 'memapp' is a web application created in the
     Shiny framework for the `r pkg("mem")` R package.
 -   `r pkg("nosoi")`: The aim of `r pkg("nosoi")` (pronounced no.si) is to
     provide a flexible agent-based stochastic transmission chain/epidemic
-    simulator ([Lequime et al. 2020](https://doi.org/2020.03.03.973107)). It is
-    named after the daimones of plague, sickness and disease that escaped
-    Pandora's jar in the Greek mythology. `r pkg("nosoi")` is able to take into
-    account the influence of multiple variable on the transmission process (e.g.
-    dual-host systems (such as arboviruses), within-host viral dynamics,
-    transportation, population structure), alone or taken together, to create
-    complex but relatively intuitive epidemiological simulations.
+    simulator ([Lequime et al. 2020](https://doi.org/2020.03.03.973107)). The
+    package can take into account the influence of multiple variables on the
+    transmission process (e.g.  dual-host systems such as arboviruses,
+    within-host viral dynamics, transportation, population structure), alone or
+    taken together, to create complex but relatively intuitive epidemiological
+    simulations.
 -   `r pkg("riskCommunicator")`: Estimates flexible epidemiological effect
     measures including both differences and ratios using the parametric
     G-formula developed as an alternative to inverse probability weighting. It
@@ -165,9 +168,8 @@ and exploration of epidemiological data.
 -   `r pkg("RSurveillance")`: Provides a diverse set of functions useful for the
     design and analysis of disease surveillance activities.
 -   `r pkg("trendeval")`: Provides a coherent interface for evaluating models
-    fit with the trending package. This package is part of the
-    [RECON](https://www.repidemicsconsortium.org/) toolkit for outbreak
-    analysis.
+    fit with the trending
+    package. [RECON](https://www.repidemicsconsortium.org/) package.
 -   `r pkg("SpatialEpi")`: Methods and data for cluster detection and disease
     mapping.
 -   `r pkg("surveillance")`: Statistical methods for the modeling and monitoring
@@ -180,36 +182,35 @@ and exploration of epidemiological data.
     (2016)](https://doi.org/10.18637%2Fjss.v070.i10) and a recent overview of
     the implemented space-time modeling frameworks for epidemic phenomena is
     given by [Meyer et al. (2017)](https://doi.org/10.18637%2Fjss.v077.i11).
-    Other package feature contain back-projection methods to infer time series
-    of exposure from disease onset and correction of observed time series for
-    reporting delays (nowcasting).
+    Also contains back-projection methods to infer time series of exposure from
+    disease onset and correction of observed time series for reporting delays
+    (nowcasting).
 -   `r github("reconhub/trendbreaker")` implements tools for detecting changes
     in temporal trends of a single response variable. It implements the
     **A**utomatic **S**election of **M**odels and **O**utlier **De**tection for
     **E**pidemmics (ASMODEE), an algorithm originally designed for detecting
-    changes in COVID-19 case incidence.
+    changes in COVID-19 case
+    incidence. [RECON](https://www.repidemicsconsortium.org/) package.
 -   `r pkg("trending")`: Provides a coherent interface to multiple modelling
     tools for fitting trends along with a standardised approach for generating
-    confidence and prediction intervals.
+    confidence and prediction
+    intervals. [RECON](https://www.repidemicsconsortium.org/) package.
 
 ### Estimation of transmissibility
 
 -   `r pkg("earlyR")`: Implements a simple, likelihood-based estimation of the
-    reproduction number (R0) using a branching process with a Poisson
-    likelihood. This model requires knowledge of the serial interval
-    distribution, and dates of symptom onsets. Infectiousness is determined by
-    weighting R0 by the probability mass function of the serial interval on the
-    corresponding day. It is a simplified version of the model introduced by
-    [Cori et al. (2013)](https://doi.org/10.1093%2Faje%2Fkwt133).
+    reproduction number (R0) using a Poisson branching process. This model
+    requires knowledge of the serial interval distribution, and dates of symptom
+    onsets. It is a simplified version of the model introduced by [Cori et
+    al. (2013)](https://doi.org/10.1093%2Faje%2Fkwt133).
 -   `r pkg("endtoend")`: Computes the expectation of the number of transmissions
     and receptions considering an End-to-End transport model with limited number
     of retransmissions per packet. It provides theoretical results and also
     estimated values based on Monte Carlo simulations. It is also possible to
     consider random data and ACK probabilities.
--   `r pkg("EpiEstim")`: Tools to quantify transmissibility throughout an
-    epidemic from the analysis of time series of incidence as described in [Cori
-    et al. (2013)](https://doi.org/10.1093/aje/kwt133) and [Wallinga and Teunis
-    (2004)](https://doi.org/10.1093/aje/kwh255).
+-   `r pkg("EpiEstim")`: Provides tools for estimating time-varying
+    transmissibility using the instantaneous reproduction number (Rt) introduced
+    in [Cori et al. (2013)](https://doi.org/10.1093/aje/kwt133).
 -   `r pkg("epimdr")`: Functions, data sets and shiny apps for "Epidemics:
     Models and Data in R" by Ottar N. Bjornstad ([ISBN
     978-3-319-97487-3](https://www.springer.com/gp/book/9783319974866)). The
@@ -222,42 +223,28 @@ and exploration of epidemiological data.
 -   `r pkg("epinet")`: A collection of epidemic/network-related tools. Simulates
     transmission of diseases through contact networks. Performs Bayesian
     inference on network and epidemic parameters, given epidemic data.
--   `r github("epiforecasts/EpiNow2")`: This package estimates the time-varying
-    reproduction number, rate of spread, and doubling time using a range of
-    open-source tools ([Abbott et
-    al.](https://doi.org/10.12688/wellcomeopenres.16006.1)), and current best
-    practices ([Gostic et al.](https://doi.org/10.1371/journal.pcbi.1008409)).
-    It aims to help users avoid some of the limitations of naive implementations
-    in a framework that is informed by community feedback and is under active
-    development.
+-   `r github("epiforecasts/EpiNow2")`: Provides tools for estimating the
+    time-varying reproduction number, rate of spread, and doubling time of
+    epidemics while accounting for various delays using the approach introducted
+    in ([Abbott et al.](https://doi.org/10.12688/wellcomeopenres.16006.1)), and
+    ([Gostic et al.](https://doi.org/10.1371/journal.pcbi.1008409)).
 -   `r pkg("nbTransmission")`: Estimates the relative transmission probabilities
-    between cases in an infectious disease outbreak or cluster using naive
-    Bayes. Included are various functions to use these probabilities to estimate
-    transmission parameters such as the generation/serial interval and
-    reproductive number as well as finding the contribution of covariates to the
-    probabilities and visualizing results. The ideal use is for an infectious
-    disease dataset with metadata on the majority of cases but more informative
-    data such as contact tracing or pathogen whole genome sequencing on only a
-    subset of cases. For a detailed description of the methods see [Leavitt et
-    al. (2020)](https://doi.org/10.1093%2Fije%2Fdyaa031).
+    between cases using naive Bayes as introduced in [Leavitt et
+    al. (2020)](https://doi.org/10.1093%2Fije%2Fdyaa031). Includes various
+    functions to estimate transmission parameters such as the generation/serial
+    interval and reproductive number as well as finding the contribution of
+    covariates to transmission probabilities and visualizing results.
 -   `r pkg("R0")`: Estimation of reproduction numbers for disease outbreak,
-    based on incidence data. The R0 package implements several documented
-    methods. It is therefore possible to compare estimations according to the
-    methods used. Depending on the methods requested by user, basic reproduction
-    number (commonly denoted as R0) or real-time reproduction number (referred
-    to as R(t)) is computed, along with a 95% Confidence Interval. Plotting
-    outputs will give different graphs depending on the methods requested :
-    basic reproductive number estimations will only show the epidemic curve
-    (collected data) and an adjusted model, whereas real-time methods will also
-    show the R(t) variations throughout the outbreak time period. Sensitivity
-    analysis tools are also provided, and allow for investigating effects of
-    varying Generation Time distribution or time window on estimates.
+    based on incidence data including the basic reproduction number (R0) and the
+    instantaneous reproduction number (R(t)), alongside corresponding 95%
+    Confidence Interval. Also includes routines for plotting outputs and for
+    performing sensitivity analyses.
 -   `r pkg("tsiR")`: The TSIR modeling framework allows users to fit the time
     series SIR model to cumulative case data, which uses a regression equation
     to estimate transmission parameters based on differences in cumulative cases
     between reporting periods. The package supports inference on TSIR parameters
     using GLMs and profile likelihood techniques, as well as forward simulation
-    based on a fitted model. The package is described in [Becker and Grenfell
+    based on a fitted model, as described in [Becker and Grenfell
     (2017)](https://doi.org/10.1371/journal.pone.0185528).
 
 ### Compartmental models

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -6,31 +6,36 @@ email: thibautjombart@gmail.com
 version: 2022-05-30
 ---
 
-Contributors (in alphabetic order): Neale Batra, Rich FitzJohn, Hugo Gruson,
-Andreas Handel, Michael Höhle, Thibaut Jombart, Joseph Larmarange, Sebastian
-Lequime, Alex Spina, Tim Taylor, Sean Wu
+Contributors (in alphabetic order): Neale Batra, Solène Cadiou, Christopher
+Endres, Rich FitzJohn, Hugo Gruson, Andreas Handel, Michael Höhle, Thibaut
+Jombart, Joseph Larmarange, Sebastian Lequime, Alex Spina, Tim Taylor, Sean Wu,
+Achim Zeileis
 
 ## Overview
 
-R is increasingly becoming a standard in infectious disease epidemiology (IDE),
-providing a wide array of tools covering different aspects of outbreak analytics
-from study design to data exploration, modelling, forecasting and simulation.
-This task view provides an overview of packages specifically developed for
-IDE. It does not encompass other applications of epidemiology (such as
-environmental epidemiology) or cross-cutting tools used in, but not specific to,
-IDE.
+R is increasingly becoming a standard in epidemiology, providing a wide array of
+tools from study design to epidemiological data exploration, modelling,
+forecasting and simulation. This task view provides an overview of packages
+specifically developed for epidemiology, including infectious disease
+epidemiology (IDE) and environmental epidemiology. It does not include:
+
+* generic tools which are used in these domains but not specifically developed
+for the epidemiological context
+* '*omics*' approaches and genome-wide association studies (GWAS), which can be
+  used in epidemiology but form a largely separate domain 
 
 Packages were regrouped in the following categories:
 
-1.  **Data exploration and visualisation:** these tools are dedicated to
-    handling and visualising IDE data, producing epidemic curves
-    ('*epicurves*'), exploring contact tracing data, etc.
-2.  **Infectious disease modelling:** these tools encompass various approaches
-    for the analysis of epidemic curves (including outbreak detection /
-    surveillance), estimating reproduction numbers (*R*), providing short-term
-    forecasting, implementing compartmental models (e.g. SIR models), simulating
-    outbreaks and reconstructing transmission trees
-3.  **Helpers**: tools implementing miscellaneous tasks useful in IDE
+1.  **Data visualisation:** tools dedicated to handling and
+    visualisation of epidemiological data, *e.g.* epidemic curves ('*epicurves*'),
+    exploration of contact tracing networks, etc.
+2.  **Infectious disease modelling:** IDE-specific packages for the analysis of
+    epidemic curves (including outbreak detection / surveillance), estimation of
+    transmissibility, short-term forecasting, compartmental models (*e.g.*  SIR
+    models), simulation of outbreaks, and reconstruction of transmission trees
+3.  **Environmental epidemiology:** tools dedicated to the study of
+    environmental factors acting as determinants of diseases
+3.  **Helpers**: tools implementing miscellaneous tasks useful in epidemioliogy
 4.  **Data packages**: these packages provide access to both empirical and
     simulated epidemic data; includes a specific section on COVID-19.
 
@@ -40,10 +45,10 @@ manipulate dates, etc.) are provided in the task view's footnotes.
 ## Inclusion criteria
 
 Packages included in this task view were identified through recommendations of
-IDE experts as well as an automated CRAN search using `pkgsearch::pkg_search()`,
-with the keywords: *epidemiology*, *epidemic*, *epi*, *outbreak* and
-*transmission*. The list was manually curated for the final selection to satisfy
-the conditions described in the previous paragraph.
+expert epidemiologists as well as an automated CRAN search using
+`pkgsearch::pkg_search()` with the keywords: *epidemiology*, *epidemic*, *epi*,
+*outbreak* and *transmission*. The list was manually curated for the final
+selection to satisfy the conditions described in the previous paragraph.
 
 Packages are deemed in scope if they provide tools, or data, explicitly targeted
 at reporting, modelling, or forecasting infectious diseases.
@@ -54,17 +59,18 @@ an issue at:
 https://github.com/bisaloo/Epidemiology
 
 
-## Data visualisation and exploration
+## Data visualisation
 
-Here are packages providing help for visualising and exploring epidemic data
-(plotting epidemic curves, incidence curves, contact tracing, etc.)
+This section includes packages providing specific tools for the visualisation
+and exploration of epidemiological data.
 
--   `r pkg("epicontacts")`: A collection of tools for representing
-    epidemiological contact data, composed of case line lists and contacts
-    between cases. Also contains procedures for data handling, interactive
-    graphics, and statistics.
+-   `r pkg("epicontacts")`: Implements a dedicated class for contact data,
+    composed of case line lists and contacts between cases. Also includes
+    procedures for data handling, interactive graphics, and characterizing
+    contact patterns (*e.g.* mixing patterns, serial
+    intervals). [RECON](https://www.repidemicsconsortium.org/) package.
 -   `r pkg("EpiContactTrace")`: Routines for epidemiological contact tracing and
-    visualisation of network of contacts.
+    visualisation of networks of contacts.
 -   `r pkg("EpiCurve")`: Creates simple or stacked epidemic curves for hourly,
     daily, weekly or monthly outcome data.
 -   `r pkg("epiDisplay")`: Package for data exploration and result presentation.
@@ -72,34 +78,29 @@ Here are packages providing help for visualising and exploring epidemic data
     visualise epidemiological flows of people between locations. Also contains a
     statistical method for predicting disease spread from flow data initially
     described in [Dorigatti et al.
-    (2017)](https://doi.org/10.2807%2F1560-7917.ES.2017.22.28.30572). This
-    package is part of the [RECON](https://www.repidemicsconsortium.org/)
-    toolkit for outbreak analysis.
+    (2017)](https://doi.org/10.2807%2F1560-7917.ES.2017.22.28.30572). [RECON](https://www.repidemicsconsortium.org/)
+    package.
 -   `r pkg("EpiReport")`: Drafting an epidemiological report in 'Microsoft Word'
     format for a given disease, similar to the Annual Epidemiological Reports
     published by the European Centre for Disease Prevention and Control.
+-   `r pkg("incidence")`: Functions and classes to compute, handle and visualise
+    incidence from dated events for a defined time interval, using various date
+    formats. Also provides wrappers for log-linear models of incidence and
+    estimation of daily growth
+    rate. [RECON](https://www.repidemicsconsortium.org/) package. This package
+    is scheduled for deprecation and is replaced by `r pkg("incidence2")`.
+-   `r pkg("incidence2")`: Provides functions and classes to compute, handle and
+    visualise incidence from dated events. Improves the original `r
+    pkg("incidence")` package in many ways: full flexibility in time intervals
+    used, allows multiple stratifications, and is fully compatible with `r
+    pkg("dplyr")` and other tidyverse tools.
+    [RECON](https://www.repidemicsconsortium.org/) package.
 -   `r pkg("i2extras")`: Provides functions to work with 'incidence2' objects,
     including a simplified interface for trend fitting, estimation of growth
-    rates, and peak estimation. This package is part of the
-    [RECON](https://www.repidemicsconsortium.org/) toolkit for outbreak
-    analysis.
--   `r pkg("incidence")`: Provides functions and classes to compute, handle and
-    visualise incidence from dated events for a defined time interval. Dates can
-    be provided in various standard formats. The class 'incidence' is used to
-    store computed incidence and can be easily manipulated, subsetted, and
-    plotted. In addition, log-linear models can be fitted to 'incidence' objects
-    using 'fit'. This package is part of the
-    [RECON](https://www.repidemicsconsortium.org/) toolkit for outbreak
-    analysis, but is now scheduled for deprecation and is replaced by
-    `r pkg("incidence2")`.
--   `r pkg("incidence2")`: Provides functions and classes to compute, handle and
-    visualise incidence from dated events for a defined time interval. Improves
-    the original `r pkg("incidence")` package in many ways: full flexibility in
-    time intervals used, allows multiple stratification, and is fully compatible
-    with `r pkg("dplyr")` and other tidyverse tools. This package is part of the
-    [RECON](https://www.repidemicsconsortium.org/) toolkit for outbreak
-    analysis.
-
+    rates, and peak estimation. [RECON](https://www.repidemicsconsortium.org/)
+    package.
+	
+	
 ## Infectious disease modelling
 
 ### Epidemics surveillance

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -192,7 +192,7 @@ task views.
     changes in COVID-19 case
     incidence. [RECON](https://www.repidemicsconsortium.org/) package.
 -   `r pkg("trending")`: Provides a coherent interface to multiple modelling
-    tools for fitting trends along with a standardised approach for generating
+    tools for fitting trends along with a standardized approach for generating
     confidence and prediction
     intervals. [RECON](https://www.repidemicsconsortium.org/) package.
 
@@ -349,18 +349,18 @@ task views.
     information on the self-controlled case series method and its extensions
     with more examples at <https://sccs-studies.info>.
 
-## Helper functions
+## Helpers
 
-Here are packages providing useful helper functions for practicing, teaching and
-learning epidemiology (eg computing sample size, contingency tables, etc).
+This section includes packages providing tools to facilitate epidemiological
+analysis as well as for training (e.g. computing sample size, contingency
+tables, etc).
 
 -   `r pkg("DSAIDE")`: Exploration of simulation models (apps) of various
     infectious disease transmission dynamics scenarios. The purpose of the
     package is to help individuals learn about infectious disease epidemiology
-    (ecology/evolution) from a dynamical systems perspective. All apps include
-    explanations of the underlying models and instructions on what to do with
-    the models.
--   `r pkg("epibasix")`: Contains elementary tools for analysis of common
+    from a dynamical systems perspective. All apps include explanations of the
+    underlying models and instructions on what to do with the models.
+-   `r pkg("epibasix")`: Contains elementary tools for analyzing common
     epidemiological problems, ranging from sample size estimation, through 2x2
     contingency table analysis and basic measures of agreement (kappa,
     sensitivity/specificity). Appropriate print and summary statements are also
@@ -381,8 +381,14 @@ learning epidemiology (eg computing sample size, contingency tables, etc).
     including methods for two-way and multi-way contingency tables.
 -   `r pkg("epitrix")`: A collection of small functions useful for epidemics
     analysis and infectious disease modelling. This includes computation of
-    basic reproduction numbers from growth rates, generation of hashed labels to
-    anonymise data, and fitting discretised Gamma distributions.
+    basic reproduction numbers (R0) from daily growth rates, generation of
+    hashed labels to anonymise data, and fitting discretized Gamma
+    distributions.
+-   `r pkg("linelist")`: Implements the `linelist` class for storing case line
+    list data, which extends `data.frame` and `tibble` by adding the ability to
+    tag key epidemiological variables, validate them, and providing safeguards
+    against accidental deletion or alteration of these data to help make data
+    pipelines more straightforward and robust.
 -   `r pkg("powerSurvEpi")`: Functions to calculate power and sample size for
     testing main effect or interaction effect in the survival analysis of
     epidemiological studies (non-randomized studies), taking into account the
@@ -509,21 +515,16 @@ COVID-19 section.
     large, single-centre, multimodal relational database consisting of
     information (using acknowledged sources) related to COVID-19 pandemic. This
     package provides an R-specific interface to the OxCOVID19 Database based on
-    widely-used data handling and manipulation approaches in R.    
+    widely-used data handling and manipulation approaches in R.
 
 ## Links
 
 -   R Epidemics Consortium (RECON), non-profit organisation developing
-    professional tools for field epidemiologists:
+    outbreak analytics tools:
     <https://www.repidemicsconsortium.org/projects/>
 
--   RECON's task manager, issues regarding infectious epidemiology packages from
-    RECON packages and partners: <https://tasks.repidemicsconsortium.org>
-
--   Survival analysis task view: `r view("Survival")`
-
--   Data visualisation and graphics task view: `r view("Graphics")`
-
--   Meta analysis task view: `r view("MetaAnalysis")`
-
--   Multivariate statistics task view: `r view("Multivariate")`
+-   [*Epiverse*](https://data.org/initiatives/epiverse/), an initiative created
+    by [data.org](data.org) for the development of open-source resources for
+    epidemic preparedness and
+    response. [*Epiverse-TRACE*](https://github.com/epiverse-trace) is dedicated
+    to creating an ecosystem of R packages for outbreak analytics.

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -272,21 +272,13 @@ task views.
     disease types. EpiModel features an API for extending these templates to
     address novel scientific research aims. Full methods for EpiModel are
     detailed in [Jenness et al. (2018)](https://doi.org/10.18637/jss.v084.i08).
--   `r pkg("odin")`: Generate systems of ordinary differential equations (ODE)
-    and integrate them, using a domain specific language (DSL). The DSL uses R's
-    syntax, but compiles to C in order to efficiently solve the system. A solver
-    is not provided, but instead interfaces to the packages `r pkg("deSolve")`
-    and `r pkg("dde")` are generated. With these, while solving the differential
-    equations, no allocations are done and the calculations remain entirely in
-    compiled code. Alternatively, a model can be transpiled to R for use in
-    contexts where a C compiler is not present. After compilation, models can be
-    inspected to return information about parameters and outputs, or
-    intermediate values after calculations. `r pkg("odin")` is not targeted at
-    any particular domain and is suitable for any system that can be expressed
-    primarily as mathematical expressions. Additional support is provided for
-    working with delays (delay differential equations, DDE), using interpolated
-    functions during interpolation, and for integrating quantities that
-    represent arrays.
+-   `r pkg("odin")`: Provides a generic, fast and computer-efficient platform
+    for implementing any deterministic or stochastic compartmental models
+    (e.g. SIR, SEIR, SIRS, ...), and can include age stratification or
+    spatialisation. It uses a domain specific language (DSL) to specify systems
+    of ordinary differential equations (ODE) and integrate them. The DSL uses
+    R's syntax, but compiles to C in order to efficiently solve the system,
+    using interfaces to the packages `r pkg("deSolve")` and `r pkg("dde")`.
 -   `r pkg("pomp")` Provides a large set of forward simulation algorithms and
     MLE or Bayesian inference techniques to work with state-space models. Models
     may be specified as either deterministic or stochastic and typically follow
@@ -311,20 +303,17 @@ task views.
     births, deaths and movements as scheduled events at predefined time-points.
     Using C code for the numerical solvers and 'OpenMP' (if available) to divide
     work over multiple processors ensures high performance when simulating a
-    sample outcome. One of our design goals was to make the package extendable
-    and enable usage of the numerical solvers from other R extension packages in
-    order to facilitate complex epidemiological research. The package contains
-    template models and can be extended with user-defined models. For more
-    details see the paper by [Widgren, Bauer, Eriksson and Engblom
-    (2019)](https://doi.org/10.18637%2Fjss.v091.i12).
+    sample outcome. The package contains template models and can be extended
+    with user-defined models. For more details see the paper by [Widgren, Bauer,
+    Eriksson and Engblom (2019)](https://doi.org/10.18637%2Fjss.v091.i12).
 -   `r pkg("socialmixr")`: Provides methods for sampling contact matrices from
     diary data for use in infectious disease modelling, as discussed in [Mossong
     et al. (2008)](https://doi.org/10.1371%2Fjournal.pmed.0050074).
 
 ### Transmission tree reconstruction
 
--   `r pkg("adegenet")`: while primarily a population genetics package,
-    `r pkg("adegenet")` also implements seqtrack ([Jombart et al.
+-   `r pkg("adegenet")`: primarily a population genetics package,
+    `r pkg("adegenet")` implements seqtrack ([Jombart et al.
     2011](https://doi.org/10.1038%2Fhdy.2010.78)), a maximum-parsimony approach
     for reconstructing transmission trees using the Edmonds/Chu-Liu algorithm
 -   `r pkg("o2geosocial")` (`r pkg("outbreaker2")` module): Bayesian
@@ -336,11 +325,16 @@ task views.
 -   `r github("xavierdidelot/o2mod.transphylo")` is a module of
     `r pkg("outbreaker2")` which uses the `r pkg("TransPhylo")` model of
     within-host evolution.
--   `r pkg("outbreaker2")`: Bayesian reconstruction of disease outbreaks using
-    epidemiological and genetic information. [Jombart T, Cori A, Didelot X,
-    Cauchemez S, Fraser C and Ferguson N.
-    2014](https://doi.org/10.1371/journal.pcbi.1003457), [Campbell F, Cori A,
-    Ferguson N, Jombart T. 2019](https://doi.org/10.1371/journal.pcbi.1006930).
+-   `r pkg("outbreaker2")`: a modular platform for Bayesian reconstruction of
+    disease outbreaks using epidemiological and genetic information as
+    introduced in [Jombart T, Cori A, Didelot X, Cauchemez S, Fraser C and
+    Ferguson N.  2014](https://doi.org/10.1371/journal.pcbi.1003457), [Campbell
+    F, Cori A, Ferguson N, Jombart
+    T. 2019](https://doi.org/10.1371/journal.pcbi.1006930). Different modules
+    can be used for different types of data (timing of epidemiological events,
+    pathogen genomes, contact between patients, locations). A fully documented
+    API facilitates writing new modules and extensions, where custom
+    likelihoods, priors, and MCMC can be provided as R or C++ code.
 -   `r pkg("TransPhylo")`: Inference of transmission tree from a dated
     phylogeny. Includes methods to simulate and analyse outbreaks. The
     methodology is described in [Didelot et al.

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -568,9 +568,9 @@ COVID-19 section.
 
 ## Links
 
--   The R Epidemics Consortium (RECON), non-profit organisation developing
-    outbreak analytics tools:
-    <https://www.repidemicsconsortium.org/projects/>
+-   The R Epidemics Consortium ([RECON](https://www.repidemicsconsortium.org)),
+    a non-profit organisation dedicated to the development of free, open-source
+    outbreak analytics resources.
 
 -   [*Epiverse*](https://data.org/initiatives/epiverse/), an initiative created
     by [data.org](data.org) for the development of open-source resources for

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -354,14 +354,41 @@ Environmental epidemiology is dedicated to the study of physical, chemical, and
 biologic agents in the environment acting as determinants of disease. The aims
 of environmental epidemiology are to infer causality, to identify environmental
 causes of disease, such as from air and water pollutants, dietary contaminants,
-built environments, and others (Bloom et al., 2018).
+built environments, and others.
 
-Exposure to pollutants are commonly measured with devices that have a minimal
-threshold under which the exposure of interest cannot be measured and
-differentiated from zero, this limit is called the limit of detection
-(LOD). Many methods have been developed to take into account this left side
-censorship and are useful to pre-process environmental exposure data (eg. to
-impute values below the LOD) and to compute left censored statistics.
+R packages dedicated to environmental epidemiology include tools dealing with
+limits of detection of pollutants (left-censoring issues), and various modelling
+approaches to account for multiple correlations between exposures and infer
+causality.
+
+-   `r pkg("NADA")`: Nondetects and Data Analysis for Environmental Data,
+    package containing all the functions derived from the methods in [Helsel
+    (2011)](https://www.wiley.com/en-us/Statistics+for+Censored+Environmental+Data+Using+Minitab+and+R%2C+2nd+Edition-p-9780470479889).
+-   `r pkg("EnvStats")`: Package for Environmental Statistics, Including US EPA
+    Guidance, graphical and statistical analyses of environmental data, with
+    focus on analyzing chemical concentrations and physical parameters, usually
+    in the context of mandated environmental monitoring. Major environmental
+    statistical methods found in the literature and regulatory guidance
+    documents, with extensive help that explains what these methods do, how to
+    use them, and where to find them in the literature. Numerous built-in data
+    sets from regulatory guidance documents and environmental statistics
+    literature [(Millard
+    2013)](https://link.springer.com/book/10.1007/978-1-4614-8456-1).
+-   `r pkg("bkmr")`: Implements Bayesian Kernel Machine Regression, a
+	statistical approach for estimating the joint health effects of multiple
+	concurrent exposures, as described in Bobb *et al.*
+	[(2015)](https://academic.oup.com/biostatistics/article/16/3/493/269719)
+-   `r pkg("mediation")`: Implements parametric and non parametric mediation
+    analysis as discussed in Imai *et al.*
+    [(2010)](http://dx.doi.org/10.1214/10-sts321).
+-   `r pkg("mma")`: Implements multiple mediation analysis as described in Yu
+	*et al.*  [(2017)](https://doi.org/10.1016%2Fj.sste.2017.02.001).
+-   `r pkg("HIMA")`: Allows to estimate and test high-dimensional mediation
+    effects based on advanced mediator screening and penalized regression
+    techniques ([Zhang *et al.*
+    2021])(https://doi.org/10.1093%2Fbioinformatics%2Fbtab564).
+
+
 
 
 

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -568,7 +568,7 @@ COVID-19 section.
 
 ## Links
 
--   R Epidemics Consortium (RECON), non-profit organisation developing
+-   The R Epidemics Consortium (RECON), non-profit organisation developing
     outbreak analytics tools:
     <https://www.repidemicsconsortium.org/projects/>
 
@@ -577,3 +577,5 @@ COVID-19 section.
     epidemic preparedness and
     response. [*Epiverse-TRACE*](https://github.com/epiverse-trace) is dedicated
     to creating an ecosystem of R packages for outbreak analytics.
+
+-  The R [handbook](https://epirhandbook.com/en/) for field epidemiology.

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -272,6 +272,11 @@ task views.
     disease types. EpiModel features an API for extending these templates to
     address novel scientific research aims. Full methods for EpiModel are
     detailed in [Jenness et al. (2018)](https://doi.org/10.18637/jss.v084.i08).
+-   `r pkg("SCCS")`: Self-controlled case series models used to investigate
+    associations between time-varying exposures such as vaccines or other drugs
+    or non drug exposures and an adverse event can be fitted. Detailed
+    information on the self-controlled case series method and its extensions
+    with more examples at <https://sccs-studies.info>.
 -   `r pkg("odin")`: Provides a generic, fast and computer-efficient platform
     for implementing any deterministic or stochastic compartmental models
     (e.g. SIR, SEIR, SIRS, ...), and can include age stratification or
@@ -341,13 +346,24 @@ task views.
     (2014)](https://doi.org/10.1093%2Fmolbev%2Fmsu121), [Didelot et al.
     (2017)](https://doi.org/10.1093%2Fmolbev%2Fmsw275).
 
-### Vaccination
 
--   `r pkg("SCCS")`: Self-controlled case series models used to investigate
-    associations between time-varying exposures such as vaccines or other drugs
-    or non drug exposures and an adverse event can be fitted. Detailed
-    information on the self-controlled case series method and its extensions
-    with more examples at <https://sccs-studies.info>.
+
+## Environmental epidemiology
+
+Environmental epidemiology is dedicated to the study of physical, chemical, and
+biologic agents in the environment acting as determinants of disease. The aims
+of environmental epidemiology are to infer causality, to identify environmental
+causes of disease, such as from air and water pollutants, dietary contaminants,
+built environments, and others (Bloom et al., 2018).
+
+Exposure to pollutants are commonly measured with devices that have a minimal
+threshold under which the exposure of interest cannot be measured and
+differentiated from zero, this limit is called the limit of detection
+(LOD). Many methods have been developed to take into account this left side
+censorship and are useful to pre-process environmental exposure data (eg. to
+impute values below the LOD) and to compute left censored statistics.
+
+
 
 ## Helpers
 
@@ -516,6 +532,12 @@ COVID-19 section.
     information (using acknowledged sources) related to COVID-19 pandemic. This
     package provides an R-specific interface to the OxCOVID19 Database based on
     widely-used data handling and manipulation approaches in R.
+
+### Other data packages
+
+-   `r pkg("nhanesA")`: provides ready access to the National Health and
+    Nutrition Examination Survey (NHANES) data tables.
+
 
 ## Links
 

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -573,7 +573,7 @@ COVID-19 section.
     outbreak analytics resources.
 
 -   [*Epiverse*](https://data.org/initiatives/epiverse/), an initiative created
-    by [data.org](data.org) for the development of open-source resources for
+    by [data.org](https://data.org) for the development of open-source resources for
     epidemic preparedness and
     response. [*Epiverse-TRACE*](https://github.com/epiverse-trace) is dedicated
     to creating an ecosystem of R packages for outbreak analytics.

--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -1,9 +1,9 @@
 ---
-name: InfectiousEpi
-topic: Infectious Disease Epidemiology
+name: Epidemiology
+topic: Epidemiology
 maintainer: Thibaut Jombart, Matthieu Rolland, Hugo Gruson
 email: thibautjombart@gmail.com
-version: 2022-04-26
+version: 2022-05-30
 ---
 
 Contributors (in alphabetic order): Neale Batra, Rich FitzJohn, Hugo Gruson,
@@ -51,7 +51,7 @@ at reporting, modelling, or forecasting infectious diseases.
 **Your input is welcome!** Please suggest packages we may have missed by posting
 an issue at:
 
-https://github.com/bisaloo/InfectiousEpi
+https://github.com/bisaloo/Epidemiology
 
 
 ## Data visualisation and exploration

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## CRAN Task View: InfectiousEpi
+## CRAN Task View: Epidemiology
 
-**URL:** <https://CRAN.R-project.org/view=InfectiousEpi>
+**URL:** <https://CRAN.R-project.org/view=Epidemiology>
 
-**Source file:** [InfectiousEpi.md](InfectiousEpi.md)
+**Source file:** [Epidemiology.md](Epidemiology.md)
 
 **Contributions:** Suggestions and improvements for this task view are very
 welcome and can be made through issues or pull requests here on GitHub or via

--- a/proposal.md
+++ b/proposal.md
@@ -23,7 +23,7 @@ at reporting, analysing, modelling, or forecasting infectious diseases.
 # Packages
 
 A current draft for the task view, with the proposed packages and their
-description is available at: <https://github.com/Bisaloo/InfectiousEpi>
+description is available at: <https://github.com/Bisaloo/Epidemiology>
 
 Future updates will focus on adding more text and connections between packages
 to increase the added value of the task view relative to a simple list.


### PR DESCRIPTION
This revision includes the following changes:

* change of scope from Infectious Epi to Epidemiology
* edits to all sections for consistency, including cuts for lengthy descriptions and rephrasing
* removed links to task views at the end, but included some in main text
* added the packages *linelist* and *nhanesA*
* shortened additional sentences for RECON packages
* links: added link to epiverse and R field epi handbook
* using AE rather than BE throughout
* removed 'vaccination' subsection as it had a single pkg, which has been moved to 'compartmental models'
* added a section on Environmental Epi based on Matthieu Rolland's work, but only retaining specifically envir epi packages (removing general purpose modelling tools)